### PR TITLE
feat(history): add getOrigin method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,13 @@ export class History {
   }
 
   /**
+   * Returns the fully-qualified root of the current history object.
+   */
+  getAbsoluteRoot(): string {
+    throw new Error('History must implement getAbsoluteRoot().');
+  }
+
+  /**
    * Causes a history navigation to occur.
    *
    * @param fragment The history fragment to navigate to.


### PR DESCRIPTION
Per https://github.com/aurelia/router/issues/88 we want to be able to generate an absolute URI with the `router.generate()` method. That method relies upon the history module. `getOrigin` allows the router to generate an absolute URI with the protocol, hostname, and port.