### PR TITLE
feat(history) add history page state setter and getter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,4 +70,22 @@ export class History {
   setTitle(title: string): void {
     mi('setTitle');
   }
+
+  /**
+   * Sets a key in the history page state.
+   * @param key The key for the value.
+   * @param value The value to set.
+   */
+  setState(key: string, value: any): void {
+    mi('setState');
+  }
+
+  /**
+   * Gets a key in the history page state.
+   * @param key The key for the value.
+   * @returns The value for the key.
+   */
+  getState(key: string): any {
+    mi('getState');
+  }
 }


### PR DESCRIPTION
Set and get a key's value for the current page in the history.

Connected to PR history-browser/page-state (aurelia/history-browser#25).